### PR TITLE
Propuesta de página de mentores

### DIFF
--- a/listado-mentores.md
+++ b/listado-mentores.md
@@ -1,0 +1,206 @@
+# Listado de mentores - Updated 08/10/2018
+
+> Este pretende ser un listado sencillo de mentores disponibles para que en los Guilds se sepa a quién acudir y cuándo.
+
+*Para cualquier cosa que necesites, no dudes en contactar con @KoolTheba en SLACK o con @Ulisesgascon*
+
+
+## Mentores
+### Ulises Gascón
+
+![Ulises Gascón](https://secure.gravatar.com/avatar/7c94524aed875befcc22e0e823870a62.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0004-192.png)
+
+Developer y co-fundador
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/ulisesgascon)
+
+
+
+### Jose
+
+![Jose](https://avatars.slack-edge.com/2018-04-26/355124622151_fad0065b0570880715d6_192.png)
+
+Fundador junto con otros locos
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/josheriff)
+
+
+
+### Carlos Hernandez
+
+![Carlos Hernandez](https://avatars.slack-edge.com/2016-11-02/99734000515_e63f1565bbb8808e0971_192.png)
+
+I code, own an unicorn, and obey a white cat.
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/codingcarlos)
+
+
+
+### Chelo Quilón
+
+![Chelo Quilón](https://avatars.slack-edge.com/2018-05-12/362707755042_cb0d0e86389fb41181ed_192.jpg)
+
+Desarrolladora FullStack y formadora en diversas tecnologías. Colaboro en proyectos Open Source como Pillars.js. Feminista.
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/lilxelo)
+
+
+
+### Ángel Corral Arias
+
+![Ángel Corral Arias](https://avatars.slack-edge.com/2018-01-29/305706837408_4807ec3ec1fd93060478_192.png)
+
+Escribo códigos que construyen las interfaces que diseño pensando en la gente que las va a usar. También enseño cómo en Fictizia.
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/ancoar)
+
+
+
+### Javier Gallego Martin
+
+![Javier Gallego Martin](https://avatars.slack-edge.com/2017-10-24/262260123655_b72325f8067ffd1f26fc_192.jpg)
+
+
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/bifuer)
+
+
+
+### Borja Godoy
+
+![Borja Godoy](https://avatars.slack-edge.com/2017-12-05/282072825957_384cbb0cf7140eeaf59c_192.jpg)
+
+
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/borjagodoy)
+
+
+
+### Adrian Ferreres
+
+![Adrian Ferreres](https://secure.gravatar.com/avatar/27390cc694b1785cb57a0579668f2f71.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0010-192.png)
+
+
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/ardiadrianadri)
+
+
+
+### Carlos Mañas
+
+![Carlos Mañas](https://secure.gravatar.com/avatar/51dfd8cccb095246a4a00f90a929b5f2.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0023-192.png)
+
+Dibujante de unicornios y frontend tuerto
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/tuerto)
+
+
+
+### Bryan McEire
+
+![Bryan McEire](https://avatars.slack-edge.com/2017-04-27/175566727906_5addbabb7efa1e8f1b80_192.jpg)
+
+Co-Founder & CTO @Spotahome
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/bryanmceire)
+
+
+
+### Jorge Baumann
+
+![Jorge Baumann](https://avatars.slack-edge.com/2018-04-10/344002548785_368f31d1b0614ce37212_192.jpg)
+
+I do front open source troll repos in github @baumannzone
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/jbaumann)
+
+
+
+### Carlos Azaustre
+
+![Carlos Azaustre](https://avatars.slack-edge.com/2018-09-04/428177521777_ab87f64263c3ea30fd27_192.jpg)
+
+JavaScript Lover
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/cazaustre)
+
+
+
+### KoolTheba
+
+![KoolTheba](https://avatars.slack-edge.com/2017-10-08/254237460215_c1514fd03c1ada519225_192.jpg)
+
+OSW Guilds Ambassador
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/gomez.teba)
+
+
+
+### Jacinto J. Cruz Nieto
+
+![Jacinto J. Cruz Nieto](https://avatars.slack-edge.com/2017-11-12/270935523315_8790c82b96c7d461bc9c_192.jpg)
+
+Training in Developa Spirit & Time Chamber
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/jacintoj.cruz)
+
+
+
+### Carlos Hernando
+
+![Carlos Hernando](https://secure.gravatar.com/avatar/8da980a2f4466f05bf026b18c04984d6.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0005-192.png)
+
+https://chernando.xyz/
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/carlos.hernando)
+
+
+
+### Jorge Barrachina
+
+![Jorge Barrachina](https://secure.gravatar.com/avatar/a64f5a2953770e3eea687bc3eac8d7fe.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0008-192.png)
+
+
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/nusquema)
+
+
+
+### Ricardo García-Duarte
+
+![Ricardo García-Duarte](https://avatars.slack-edge.com/2018-01-23/303105444274_e29dcce3a083b5299735_192.png)
+
+CTO@NC43Tech - TherapyChat, The Motion, Buyviu, Chatme, StarsBizz | http://criptomandangas.com
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/ricardo)
+
+
+
+### Carlos Crisóstomo
+
+![Carlos Crisóstomo](https://avatars.slack-edge.com/2018-02-05/309277482240_a4a8f2929580d04580f6_192.jpg)
+
+CEO/Founder at EthelHub - Cybersecurity && Research | Linux Kernel Developer | White Hat | OWASP Madrid | IoT Security Professor @MIOTI | Mastering AI
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/ccvals)
+
+
+
+### Jorge Vidal
+
+![Jorge Vidal](https://avatars.slack-edge.com/2018-05-22/369179615335_178192dd0f978af1f833_192.png)
+
+
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/jvidal)
+
+
+
+### Ric Caralca
+
+![Ric Caralca](https://avatars.slack-edge.com/2018-10-01/446521996789_f54f1a56826d7db91a85_192.jpg)
+
+
+
+[Hazle un PING en slack ;)](https://osweekends.slack.com/messages/ric)
+


### PR DESCRIPTION
Buenas, mi propuesta como dije por Slack es tener un listado vinculado al listado de Guilds donde si se necesita algo de guía en un tema concreto pueda ir y buscar a quién atacar.

**Qué está hecho**
Tirando del listado de Chernando he creado una página base todavía sin enlazar.

**Qué falta por hacer?**
Si os parece bien habría que:

1. Crear un sistema o reglas básicas para añadirse como mentor a la lista
1. Darle un poco de hamor a los datos que se van a mostrar
1. Ver dónde enlazar esta lista en el repo de Guilds

Yay or nay?
